### PR TITLE
Fix proofs about the shape of CPS programs

### DIFF
--- a/lecturenotes/16-continuations-2.scala
+++ b/lecturenotes/16-continuations-2.scala
@@ -111,9 +111,12 @@ object transform {
   reformulate the three properties of programs in
   continuation-passing style as follows:
 
-   1. All non-trivial expressions are in tail position.
+   1. All non-trivial expressions are in tail position; equivalently, all
+      expressions not in tail position are trivial.
    2. All functions take continuation arguments.
-   3. No trivial expressions are in tail position.
+   3. No trivial expressions are in tail position; equivalently, all
+      expressions that are trivial are not in tail position, and all
+      expressions that are in tail position are nontrivial.
 
   Note how the third property used to be semantic (what happens
   at run time) and became syntactic (how programs look like). The
@@ -167,7 +170,7 @@ object transform {
   Evaluation of `ContAdd` will work by evaluating the
   subexpressions first, and then doing the addition. So neither
   of the subexpressions is in tail positions, so they have to be
-  trivial, by the third property of programs in CPS. We therefore
+  trivial, by the first property of programs in CPS. We therefore
   use `TrivialContExp` for both `lhs` and `rhs`.
   */
 
@@ -188,7 +191,7 @@ object transform {
   Next we have to think about application. Evaluating an
   application means evaluating the subexpressions first and then
   calling the function. So the subexpressions are not in tail
-  position and therefore have to be trivial by the third property
+  position and therefore have to be trivial by the first property
   of programs in CPS. We therefore use `TrivalContExp` for
   `funExpr` and `argExpr`.
 


### PR DESCRIPTION
Some proofs refer to the third property instead of the first. Fix that.
There's one remaining proof that uses the third property (for the
`ContFun` case).

The first and third properties are easy to confuse but different. The
3rd means "**all** expressions that are in tail position are
nontrivial", and doesn't mean that "**only** the expressions that are in
tail position are nontrivial" — that's the first property.

Given this is confusing enough for us, I've decided to spell out the
equivalent form of these properties, but feel free to take that back out
again.